### PR TITLE
fix(appreview-web): support 페이지 추가 및 privacy 제3자 AI 고지 강화

### DIFF
--- a/src/app/(public)/_components/legal-document-layout.tsx
+++ b/src/app/(public)/_components/legal-document-layout.tsx
@@ -87,9 +87,12 @@ export function LegalDocumentLayout({
         ))}
       </div>
 
-      <footer className="mt-10 border-t border-border/70 pt-6 text-sm text-muted-foreground">
+      <footer className="mt-10 flex flex-wrap gap-4 border-t border-border/70 pt-6 text-sm text-muted-foreground">
         <Link className="font-medium text-foreground underline underline-offset-4" href={alternateHref}>
           {alternateLabel}
+        </Link>
+        <Link className="font-medium text-foreground underline underline-offset-4" href="/support">
+          고객지원
         </Link>
       </footer>
     </main>

--- a/src/app/(public)/_lib/legal-content.ts
+++ b/src/app/(public)/_lib/legal-content.ts
@@ -7,6 +7,8 @@ export type LegalSection = {
 
 export const LEGAL_OPERATOR_NAME = "오늘네일 운영팀";
 export const LEGAL_CONTACT_EMAIL = "galaxydh4110@gmail.com";
+export const LEGAL_SUPPORT_RESPONSE_TIME = "영업일 기준 1~2일 이내";
+export const LEGAL_THIRD_PARTY_AI_PROVIDER = "OpenAI";
 
 export const TERMS_EFFECTIVE_DATE = "2026년 2월 19일";
 export const PRIVACY_EFFECTIVE_DATE = "2026년 2월 19일";
@@ -124,7 +126,8 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
     id: "privacy-method",
     title: "2. 개인정보 수집 방법",
     paragraphs: [
-      "회원가입 및 로그인, 프로필 편집, AI 기능 사용, 푸시 알림 등록 과정에서 이용자가 직접 입력하거나 기기/시스템으로부터 자동 수집됩니다."
+      "회원가입 및 로그인, 프로필 편집, AI 기능 사용, 푸시 알림 등록 과정에서 이용자가 직접 입력하거나 기기/시스템으로부터 자동 수집됩니다.",
+      "AI 생성 기능은 생성 버튼 클릭 시점의 사전 안내 및 동의 절차를 거친 뒤에만 제3자 AI 서비스로 전송됩니다."
     ]
   },
   {
@@ -154,7 +157,15 @@ export const PRIVACY_SECTIONS: LegalSection[] = [
     title: "5. 제3자 제공 및 처리위탁",
     paragraphs: [
       "운영팀은 원칙적으로 이용자의 개인정보를 외부에 판매하거나 임의 제공하지 않습니다.",
-      "서비스 운영을 위해 클라우드 인프라, 인증 연동, 알림 전송 등의 업무를 외부 서비스 사업자와 연계하여 처리할 수 있습니다."
+      "서비스 운영을 위해 클라우드 인프라, 인증 연동, 알림 전송 등의 업무를 외부 서비스 사업자와 연계하여 처리할 수 있습니다.",
+      `AI 생성 기능 이용 시, 이용자가 동의한 범위에서 ${LEGAL_THIRD_PARTY_AI_PROVIDER} 등 제3자 AI 서비스로 생성 처리에 필요한 데이터가 전송될 수 있습니다.`
+    ],
+    items: [
+      "전송 항목: 손 사진, 디자인(레퍼런스) 사진, 생성 설정값(예: 모양/연장 옵션)",
+      `전송 대상: ${LEGAL_THIRD_PARTY_AI_PROVIDER}(AI 생성 처리), Supabase(저장/요청 전달 처리)`,
+      "전송 목적: AI 네일 생성 결과 제공 및 요청 처리",
+      "전송 시점: 이용자가 앱 내 사전 안내를 확인하고 동의한 후 AI 생성을 요청한 경우",
+      "이용자 통제: 앱 설정에서 AI 데이터 전송 동의를 철회할 수 있으며, 철회 후에는 AI 생성 시 재동의가 필요"
     ]
   },
   {

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -168,6 +168,9 @@ export default function RootLandingPage() {
               <a className={styles.primaryButton} href={feedbackMailtoHref}>
                 의견 보내기
               </a>
+              <a className={styles.secondaryButton} href="/support">
+                고객지원 안내
+              </a>
             </article>
           </section>
         </main>

--- a/src/app/(public)/support/page.tsx
+++ b/src/app/(public)/support/page.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import { createPageMetadata } from "@/lib/metadata";
+import {
+  LEGAL_CONTACT_EMAIL,
+  LEGAL_OPERATOR_NAME,
+  LEGAL_SUPPORT_RESPONSE_TIME
+} from "@/app/(public)/_lib/legal-content";
+
+export const metadata = createPageMetadata({
+  title: "고객지원",
+  description: "오늘네일 고객지원 및 문의 안내"
+});
+
+const supportMailtoHref = `mailto:${LEGAL_CONTACT_EMAIL}?subject=${encodeURIComponent("[오늘 네일] 고객지원 문의")}&body=${encodeURIComponent("아래 정보를 함께 보내주시면 더 빠르게 도와드릴 수 있어요.\\n\\n- 앱 버전:\\n- 기기/OS:\\n- 문제 발생 시점:\\n- 문제 내용:\\n- 재현 방법:")}`;
+
+export default function SupportPage() {
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6 sm:py-14">
+      <header className="border-b border-border/70 pb-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          Today&apos;s Nail Support
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          고객지원
+        </h1>
+        <p className="mt-4 text-sm leading-7 text-muted-foreground sm:text-base">
+          서비스 이용 중 문의, 오류 신고, 개인정보 관련 요청은 아래 채널로 접수해 주세요.
+        </p>
+      </header>
+
+      <section className="mt-8 rounded-2xl border border-border/70 bg-card p-5">
+        <h2 className="text-lg font-semibold text-foreground">문의 접수 채널</h2>
+        <dl className="mt-4 space-y-3 text-sm text-muted-foreground">
+          <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+            <dt className="min-w-24 font-medium text-foreground">운영 주체</dt>
+            <dd>{LEGAL_OPERATOR_NAME}</dd>
+          </div>
+          <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+            <dt className="min-w-24 font-medium text-foreground">문의 이메일</dt>
+            <dd>
+              <a className="underline underline-offset-4" href={supportMailtoHref}>
+                {LEGAL_CONTACT_EMAIL}
+              </a>
+            </dd>
+          </div>
+          <div className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+            <dt className="min-w-24 font-medium text-foreground">응답 기준</dt>
+            <dd>{LEGAL_SUPPORT_RESPONSE_TIME}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="mt-6 rounded-2xl border border-border/70 bg-card p-5">
+        <h2 className="text-lg font-semibold text-foreground">빠른 처리를 위한 안내</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-7 text-muted-foreground sm:text-base">
+          <li>사용 중인 앱 버전, 기기 모델, iOS 버전을 함께 알려주세요.</li>
+          <li>문제 화면 캡처와 재현 단계를 포함해 주시면 확인 속도가 빨라집니다.</li>
+          <li>개인정보 관련 요청(열람/정정/삭제/처리정지)은 제목에 &quot;개인정보 요청&quot;을 명시해 주세요.</li>
+        </ul>
+      </section>
+
+      <footer className="mt-8 flex flex-wrap gap-4 border-t border-border/70 pt-6 text-sm">
+        <Link className="font-medium underline underline-offset-4" href="/privacy">
+          개인정보처리방침
+        </Link>
+        <Link className="font-medium underline underline-offset-4" href="/terms">
+          이용약관
+        </Link>
+      </footer>
+    </main>
+  );
+}


### PR DESCRIPTION
## 요약
- App Review Support URL 대응용 `/support` 페이지 추가
- 개인정보처리방침에 제3자 AI 전송 범위/대상/목적/통제 방식 명시
- public 페이지/법률 페이지에 고객지원 링크 연결

## 변경 파일
- src/app/(public)/support/page.tsx
- src/app/(public)/_lib/legal-content.ts
- src/app/(public)/_components/legal-document-layout.tsx
- src/app/(public)/page.tsx

## 검증
- `pnpm -C /Users/dkim/DKim/10_Project/hackerton_nail_project/owner-app typecheck` 성공
- `pnpm -C /Users/dkim/DKim/10_Project/hackerton_nail_project/owner-app build` 성공

Closes #25
